### PR TITLE
Add Metal atomics backend following the AtomixCUDA package - almost verbatim.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,39 @@
+steps:
+  - label: "CUDA.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.10"
+    command: |
+      julia -e 'using Pkg
+
+                println("--- :julia: Instantiating environment")
+                Pkg.activate("lib/AtomixCUDA")
+                Pkg.develop(PackageSpec(name="Atomix", path="."))
+
+                println("+++ :julia: Running tests")
+                Pkg.test()'
+    agents:
+      queue: "juliagpu"
+      cuda: "*"
+    if: build.message !~ /\[skip tests\]/
+    timeout_in_minutes: 15
+
+  - label: "Metal.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.10"
+    command: |
+      julia -e 'using Pkg
+
+                println("--- :julia: Instantiating environment")
+                Pkg.activate("lib/AtomixMetal")
+                Pkg.develop(PackageSpec(name="Atomix", path="."))
+
+                println("+++ :julia: Running tests")
+                Pkg.test()'
+    agents:
+      queue: "juliaecosystem"
+      os: "macos"
+      arch: "aarch64"
+    if: build.message !~ /\[skip tests\]/
+    timeout_in_minutes: 15

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,46 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if Julia is already available in the PATH
+        id: julia_in_path
+        run: which julia
+        continue-on-error: true
+      - name: Install Julia, but only if it is not already available in the PATH
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+          arch: ${{ runner.arch }}
+        if: steps.julia_in_path.outcome != 'success'
+      - name: "Add the General registry via Git"
+        run: |
+          import Pkg
+          ENV["JULIA_PKG_SERVER"] = ""
+          Pkg.Registry.add("General")
+        shell: julia --color=yes {0}
+      - name: "Install CompatHelper"
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "3"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,21 +1,33 @@
 name: TagBot
+
 on:
   issue_comment:
     types:
       - created
-  push:
-    branches:
-      - actions/trigger/TagBot
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+
 jobs:
   TagBot:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
-      github.actor == 'JuliaTagBot'
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.SSH_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
     name: Test Julia ${{ matrix.julia-version }}
     steps:
-      - uses: actions/checkout@4
+      - uses: actions/checkout@v4
 
       - uses: julia-actions/setup-julia@v2
         with:
@@ -42,7 +42,7 @@ jobs:
           - '1.6'
       fail-fast: false
     steps:
-      - uses: actions/checkout@4
+      - uses: actions/checkout@v4
 
       - uses: julia-actions/setup-julia@v2
         with:
@@ -54,7 +54,7 @@ jobs:
   documenter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@4
+      - uses: actions/checkout@v4
 
       - uses: julia-actions/setup-julia@v2
       - uses: julia-actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
         julia-version:
           - '1'
           - '1.6'
-          - 'nightly'
       fail-fast: false
     name: Test Julia ${{ matrix.julia-version }}
     steps:
@@ -38,7 +37,6 @@ jobs:
         julia-version:
           - '1'
           - '1.6'
-          - 'nightly'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
-    tags: '*'
+    branches: [main, master]
+    tags: ["*"]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:
@@ -18,10 +18,13 @@ jobs:
       fail-fast: false
     name: Test Julia ${{ matrix.julia-version }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@4
+
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v2
+
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v2
@@ -39,17 +42,23 @@ jobs:
           - '1.6'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@4
+
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v2
+
       - uses: tkf/julia-aqua@v1
 
   documenter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@4
+
+      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/cache@v2
+
       - name: Install Run.jl
         run: julia -e 'using Pkg; Pkg.add(name="Run", version="0.1")'
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Manifest.toml
+*.cov

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Atomix"
 uuid = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
-version = "0.1.1-DEV"
+version = "1.0"
 
 [deps]
 UnsafeAtomics = "013be700-e6cd-48c3-b4a1-df204f14c38f"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1.7"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,30 +3,12 @@ using Atomix
 
 makedocs(
     sitename = "Atomix",
-    format = Documenter.HTML(),
     modules = [Atomix],
-    strict = [
-        :autodocs_block,
-        :cross_references,
-        :docs_block,
-        :doctest,
-        :eval_block,
-        :example_block,
-        :footnote,
-        :linkcheck,
-        :meta_block,
-        # :missing_docs,
-        :parse_error,
-        :setup_block,
-    ],
-    # Ref:
-    # https://juliadocs.github.io/Documenter.jl/stable/lib/public/#Documenter.makedocs
+    warnonly = :missing_docs
 )
 
 deploydocs(
     repo = "github.com/JuliaConcurrent/Atomix.jl",
     devbranch = "main",
     push_preview = true,
-    # Ref:
-    # https://juliadocs.github.io/Documenter.jl/stable/lib/public/#Documenter.deploydocs
 )

--- a/lib/AtomixCUDA/Project.toml
+++ b/lib/AtomixCUDA/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomixCUDA"
 uuid = "6171a885-8764-404f-b64d-f8edb1679b6f"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
-version = "0.1.0-DEV"
+version = "1.0"
 
 [deps]
 Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
@@ -9,3 +9,5 @@ CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [compat]
 julia = "1.6"
+Atomix = "1"
+CUDA = "5"

--- a/lib/AtomixMetal/LICENSE
+++ b/lib/AtomixMetal/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Takafumi Arakaki <aka.tkf@gmail.com> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/AtomixMetal/Project.toml
+++ b/lib/AtomixMetal/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomixMetal"
 uuid = "fc0d88fc-5db5-40d7-bf35-da84fd759def"
 authors = ["Andrei-Leonard Nicusan <a.l.nicusan@gmail.com> and contributors"]
-version = "0.1.0-DEV"
+version = "1.0"
 
 [deps]
 Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
@@ -9,3 +9,5 @@ Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
 
 [compat]
 julia = "1.6"
+Atomix = "1"
+Metal = "1"

--- a/lib/AtomixMetal/Project.toml
+++ b/lib/AtomixMetal/Project.toml
@@ -1,0 +1,11 @@
+name = "AtomixMetal"
+uuid = "fc0d88fc-5db5-40d7-bf35-da84fd759def"
+authors = ["Andrei-Leonard Nicusan <a.l.nicusan@gmail.com> and contributors"]
+version = "0.1.0-DEV"
+
+[deps]
+Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
+Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+
+[compat]
+julia = "1.6"

--- a/lib/AtomixMetal/README.md
+++ b/lib/AtomixMetal/README.md
@@ -1,0 +1,1 @@
+# AtomixMetal

--- a/lib/AtomixMetal/src/AtomixMetal.jl
+++ b/lib/AtomixMetal/src/AtomixMetal.jl
@@ -1,0 +1,58 @@
+# TODO: respect ordering
+module AtomixMetal
+
+using Atomix: Atomix, IndexableRef
+using Metal: Metal, MtlDeviceArray
+
+const MtlIndexableRef{Indexable<:MtlDeviceArray} = IndexableRef{Indexable}
+
+function Atomix.get(ref::MtlIndexableRef, order)
+    error("not implemented")
+end
+
+function Atomix.set!(ref::MtlIndexableRef, v, order)
+    error("not implemented")
+end
+
+@inline function Atomix.replace!(
+    ref::MtlIndexableRef,
+    expected,
+    desired,
+    success_ordering,
+    failure_ordering,
+)
+    ptr = Atomix.pointer(ref)
+    expected = convert(eltype(ref), expected)
+    desired = convert(eltype(ref), desired)
+    begin
+        old = Metal.atomic_compare_exchange_weak_explicit(ptr, expected, desired)
+    end
+    return (; old = old, success = old === expected)
+end
+
+@inline function Atomix.modify!(ref::MtlIndexableRef, op::OP, x, order) where {OP}
+    x = convert(eltype(ref), x)
+    ptr = Atomix.pointer(ref)
+    begin
+        old = if op === (+)
+            Metal.atomic_fetch_add_explicit(ptr, x)
+        elseif op === (-)
+            Metal.atomic_fetch_sub_explicit(ptr, x)
+        elseif op === (&)
+            Metal.atomic_fetch_and_explicit(ptr, x)
+        elseif op === (|)
+            Metal.atomic_fetch_or_explicit(ptr, x)
+        elseif op === xor
+            Metal.atomic_fetch_xor_explicit(ptr, x)
+        elseif op === min
+            Metal.atomic_fetch_min_explicit(ptr, x)
+        elseif op === max
+            Metal.atomic_fetch_max_explicit(ptr, x)
+        else
+            error("not implemented")
+        end
+    end
+    return old => op(old, x)
+end
+
+end  # module AtomixMetal

--- a/lib/AtomixMetal/test/AtomixMetalTests/Project.toml
+++ b/lib/AtomixMetal/test/AtomixMetalTests/Project.toml
@@ -1,0 +1,13 @@
+name = "AtomixMetalTests"
+uuid = "03c00b03-d8de-4838-97ce-ef69879af46e"
+authors = ["Andrei-Leonard Nicusan <a.l.nicusan@gmail.com> and contributors"]
+version = "0.1.0-DEV"
+
+[deps]
+Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
+AtomixMetal = "fc0d88fc-5db5-40d7-bf35-da84fd759def"
+Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+julia = "1.6"

--- a/lib/AtomixMetal/test/AtomixMetalTests/src/AtomixMetalTests.jl
+++ b/lib/AtomixMetal/test/AtomixMetalTests/src/AtomixMetalTests.jl
@@ -1,0 +1,7 @@
+module AtomixMetalTests
+
+include("utils.jl")
+include("test_core.jl")
+include("test_sugar.jl")
+
+end  # module AtomixMetalTests

--- a/lib/AtomixMetal/test/AtomixMetalTests/src/test_core.jl
+++ b/lib/AtomixMetal/test/AtomixMetalTests/src/test_core.jl
@@ -1,0 +1,63 @@
+module TestCore
+
+import AtomixMetal
+
+using Atomix
+using Metal
+using Metal: @allowscalar
+using Test
+
+using ..Utils: metal
+
+# Not implemented:
+#=
+function test_get_set()
+    A = CUDA.ones(Int, 3)
+    cuda() do
+        GC.@preserve A begin
+            ref = Atomix.IndexableRef(A, (1,))
+            x = Atomix.get(ref)
+            Atomix.set!(ref, -x)
+        end
+    end
+    @test collect(A) == [-1, 1, 1]
+end
+=#
+
+function test_cas()
+    idx = (
+        data = 1,
+        cas1_ok = 2,
+        cas2_ok = 3,
+        # ...
+    )
+    @assert minimum(idx) >= 1
+    @assert maximum(idx) == length(idx)
+
+    A = Metal.zeros(Int32, length(idx))
+    metal() do
+        GC.@preserve A begin
+            ref = Atomix.IndexableRef(A, (1,))
+            (old, success) = Atomix.replace!(ref, 0, 42)
+            A[idx.cas1_ok] = old == 0 && success
+            (old, success) = Atomix.replace!(ref, 0, 43)
+            A[idx.cas2_ok] = old == 42 && !success
+        end
+    end
+    @test collect(A) == [42, 1, 1]
+end
+
+function test_inc()
+    A = Metal.MtlVector(Int32(1):Int32(3))
+    metal() do
+        GC.@preserve A begin
+            ref = Atomix.IndexableRef(A, (1,))
+            pre, post = Atomix.modify!(ref, +, 1)
+            A[2] = pre
+            A[3] = post
+        end
+    end
+    @test collect(A) == [2, 1, 2]
+end
+
+end  # module

--- a/lib/AtomixMetal/test/AtomixMetalTests/src/test_sugar.jl
+++ b/lib/AtomixMetal/test/AtomixMetalTests/src/test_sugar.jl
@@ -1,0 +1,36 @@
+module TestSugar
+
+import AtomixMetal
+
+using Atomix: @atomic
+using Metal
+using Metal: @allowscalar
+using Test
+
+using ..Utils: metal
+
+# Not implemented:
+#=
+function test_get_set()
+    A = CUDA.ones(Int, 3)
+    cuda() do
+        GC.@preserve A begin
+            x = @atomic A[begin]
+            @atomic A[end-2] = -x
+        end
+    end
+    @test collect(A) == [-1, 1, 1]
+end
+=#
+
+function test_inc()
+    A = Metal.ones(Int32, 3)
+    metal() do
+        GC.@preserve A begin
+            @atomic A[begin] += 1
+        end
+    end
+    @test collect(A) == [2, 1, 1]
+end
+
+end  # module

--- a/lib/AtomixMetal/test/AtomixMetalTests/src/utils.jl
+++ b/lib/AtomixMetal/test/AtomixMetalTests/src/utils.jl
@@ -1,0 +1,13 @@
+module Utils
+
+using Metal
+
+function metal(f)
+    function g()
+        f()
+        nothing
+    end
+    Metal.@metal g()
+end
+
+end  # module

--- a/lib/AtomixMetal/test/Project.toml
+++ b/lib/AtomixMetal/test/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestFunctionRunner = "792026f5-ac9a-4a19-adcb-47b0ce2deb5d"
+
+[compat]
+TestFunctionRunner = "0.1"

--- a/lib/AtomixMetal/test/runtests.jl
+++ b/lib/AtomixMetal/test/runtests.jl
@@ -1,0 +1,2 @@
+using TestFunctionRunner
+TestFunctionRunner.@run


### PR DESCRIPTION
Tests pass on my Mac M3. Only changes to AtomixCUDA is the use of Int32 instead of Int - are there any plans to add support for 64-bit atomics, at least when natively supported on the M2 and up?