### PR TITLE
Allow compat with oneAPI v2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Atomix"
 uuid = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 UnsafeAtomics = "013be700-e6cd-48c3-b4a1-df204f14c38f"
@@ -21,7 +21,7 @@ AtomixOpenCLExt = "OpenCL"
 [compat]
 CUDA = "5"
 Metal = "1"
-oneAPI = "1"
+oneAPI = "1, 2"
 OpenCL = "^0.10"
 UnsafeAtomics = "0.1, 0.2, 0.3"
 julia = "1.10"


### PR DESCRIPTION
Test seem to pass locally for me:
```
julia> Pkg.test("Atomix", test_args=["--oneAPI"])
[...]
   Resolving package versions...
    Updating `/tmp/jl_G8HEWf/Project.toml`
  [8f75cd03] + oneAPI v2.0.2
    Updating `/tmp/jl_G8HEWf/Manifest.toml`
  [79e6a3ab] + Adapt v4.2.0
  [fa961155] + CEnum v0.5.0
  [ffbed154] + DocStringExtensions v0.9.3
  [e2ba6199] + ExprTools v0.1.10
  [0c68f7d7] + GPUArrays v11.2.2
  [46192b85] + GPUArraysCore v0.2.0
  [61eb1bfa] + GPUCompiler v1.2.0
  [096a3bc2] + GPUToolbox v0.1.0
  [076d061b] + HashArrayMappedTries v0.2.0
  [92d709cd] + IrrationalConstants v0.2.4
  [692b3bcd] + JLLWrappers v1.7.0
  [63c18a36] + KernelAbstractions v0.9.34
  [929cbde3] + LLVM v9.2.0
  [2ab3a3ac] + LogExpFunctions v0.3.29
  [1914dd2f] + MacroTools v0.5.15
  [aea7be01] + PrecompileTools v1.2.1
  [21216c6a] + Preferences v1.4.3
  [189a3867] + Reexport v1.2.2
  [ae029012] + Requires v1.3.0
  [71d1d633] + SPIRVIntrinsics v0.2.0
  [7e506255] + ScopedValues v1.3.0
  [6c6a2e73] + Scratch v1.2.1
  [276daf66] + SpecialFunctions v2.5.0
  [90137ffa] + StaticArrays v1.9.12
  [1e83bf80] + StaticArraysCore v1.4.3
  [10745b16] + Statistics v1.11.1
  [a759f4b9] + TimerOutputs v0.5.27
  [8f75cd03] + oneAPI v2.0.2
  [e33a78d0] + Hwloc_jll v2.12.0+0
  [dad2f222] + LLVMExtra_jll v0.0.35+0
  [700fe977] + NEO_jll v24.26.30049+0
  [6cb37087] + OpenCL_jll v2024.10.24+0
  [efe28fd5] + OpenSpecFun_jll v0.5.6+0
  [85f0d8ed] + SPIRV_LLVM_Translator_unified_jll v0.7.0+0
  [6ac6d60f] + SPIRV_Tools_jll v2024.4.0+0
⌅ [09858cae] + gmmlib_jll v22.3.20+0
⌅ [94295238] + libigc_jll v1.0.17193+0
⌅ [f4bc562b] + oneAPI_Level_Zero_Headers_jll v1.9.2+1
⌃ [13eca655] + oneAPI_Level_Zero_Loader_jll v1.17.6+0
  [b049733a] + oneAPI_Support_jll v0.7.0+0
  [4af54fe1] + LazyArtifacts v1.11.0
  [37e2e46d] + LinearAlgebra v1.11.0
  [2f01184e] + SparseArrays v1.11.0
  [e66e0078] + CompilerSupportLibraries_jll v1.1.1+0
  [4536629a] + OpenBLAS_jll v0.3.27+1
  [05823500] + OpenLibm_jll v0.8.1+2
  [bea87d4a] + SuiteSparse_jll v7.7.0+0
  [8e850b90] + libblastrampoline_jll v5.11.0+0
        Info Packages marked with ⌃ and ⌅ have new versions available. Those with ⌃ may be upgradable, but those with ⌅ are restricted by compatibility constraints from upgrading. To see why use `status --outdated -m`
Test Summary:                   | Pass  Total  Time
AtomixoneAPIExt:extension_found |    1      1  0.1s
Test Summary:            | Pass  Total   Time
AtomixoneAPIExt:test_cas |    1      1  10.7s
Test Summary:            | Pass  Total  Time
AtomixoneAPIExt:test_inc |    1      1  0.3s
Test Summary:                  | Pass  Total  Time
AtomixoneAPIExt:test_inc_sugar |    1      1  0.2s
     Testing Atomix tests passed 
```

CC: @vchuravy.