### PR TITLE
Test 1.11

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,13 @@
 steps:
-  - label: "CUDA.jl"
+  - label: "CUDA.jl {{matrix.version}}"
+    matrix:
+      setup:
+        version:
+          - "1.10"
+          - "1.11"
     plugins:
       - JuliaCI/julia#v1:
-          version: "1.10"
+          version: "{{matrix.version}}"
     command: |
       julia -e 'using Pkg
 
@@ -18,10 +23,15 @@ steps:
     if: build.message !~ /\[skip tests\]/
     timeout_in_minutes: 15
 
-  - label: "Metal.jl"
+  - label: "Metal.jl {{matrix.version}}"
+    matrix:
+      setup:
+        version:
+          - "1.10"
+          - "1.11"
     plugins:
       - JuliaCI/julia#v1:
-          version: "1.10"
+          version: "{{matrix.version}}"
     command: |
       julia -e 'using Pkg
 
@@ -38,10 +48,15 @@ steps:
     if: build.message !~ /\[skip tests\]/
     timeout_in_minutes: 15
 
-  - label: "oneAPI.jl"
+  - label: "oneAPI.jl {{matrix.version}}"
+    matrix:
+      setup:
+        version:
+          - "1.10"
+          - "1.11"
     plugins:
       - JuliaCI/julia#v1:
-          version: "1.10"
+          version: "{{matrix.version}}"
     command: |
       julia -e 'using Pkg
 
@@ -57,10 +72,15 @@ steps:
     if: build.message !~ /\[skip tests\]/
     timeout_in_minutes: 15
 
-  - label: "OpenCL.jl"
+  - label: "OpenCL.jl {{matrix.version}}"
+    matrix:
+      setup:
+        version:
+          - "1.10"
+          - "1.11"
     plugins:
       - JuliaCI/julia#v1:
-          version: "1.10"
+          version: "{{matrix.version}}"
     command: |
       julia -e 'using Pkg
 


### PR DESCRIPTION
This was in an attempt to debug a oneAPI failure that only happens in 1.11 over at https://github.com/JuliaGPU/KernelAbstractions.jl/pull/593.

Feel free to merge or close.